### PR TITLE
Validation API revamp

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,14 +105,13 @@ class EncryptedKrate(applicationContext: Context) : Krate {
 
 # Validation
 
-You can add validation rules to your Krate properties by providing an additional lambda parameter, `isValid`:
+You can add validation rules to your Krate properties by calling `validate` on any of Krate's delegate functions:
 
 ```kotlin
 var percentage: Int by intPref(
         key = "percentage",
         defaultValue = 0,
-        isValid = { it in 0..100 }
-)
+).validate { it in 0..100 }
 ```
 
 If this validation fails, an `IllegalArgumentException` will be thrown.

--- a/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
+++ b/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
@@ -15,6 +15,14 @@ import kotlin.properties.ReadWriteProperty
  * Creates a validated, optional preference of type T with the given [key] in this [Krate] instance.
  * This value will be serialized using Gson.
  */
+@Deprecated(
+        message = "Use .validate {} on a gsonPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.gsonPref<T>(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.gsonPref(
         key: String,
         noinline isValid: (newValue: T?) -> Boolean
@@ -36,6 +44,14 @@ internal fun <T : Any> Krate.gsonPrefImpl(
  * in this [Krate] instance.
  * This value will be serialized using Gson.
  */
+@Deprecated(
+        message = "Use .validate {} on a gsonPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.gsonPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.gsonPref(
         key: String,
         defaultValue: T,

--- a/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
+++ b/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
@@ -7,7 +7,7 @@ import hu.autsoft.krate.Krate
 import hu.autsoft.krate.gson.default.GsonDelegateWithDefault
 import hu.autsoft.krate.gson.optional.GsonDelegate
 import hu.autsoft.krate.internal.InternalKrateApi
-import hu.autsoft.krate.validated.ValidatedPreferenceDelegate
+import hu.autsoft.krate.validation.ValidatedPreferenceDelegate
 import java.lang.reflect.Type
 import kotlin.properties.ReadWriteProperty
 

--- a/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
+++ b/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/ValidatedFunctions.kt
@@ -25,7 +25,7 @@ import kotlin.properties.ReadWriteProperty
 )
 public inline fun <reified T : Any> Krate.gsonPref(
         key: String,
-        noinline isValid: (newValue: T?) -> Boolean
+        noinline isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return gsonPrefImpl(key, object : TypeToken<T>() {}.type, isValid)
 }
@@ -34,7 +34,7 @@ public inline fun <reified T : Any> Krate.gsonPref(
 internal fun <T : Any> Krate.gsonPrefImpl(
         key: String,
         type: Type,
-        isValid: (newValue: T?) -> Boolean
+        isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return ValidatedPreferenceDelegate(GsonDelegate(key, type), isValid)
 }
@@ -55,7 +55,7 @@ internal fun <T : Any> Krate.gsonPrefImpl(
 public inline fun <reified T : Any> Krate.gsonPref(
         key: String,
         defaultValue: T,
-        noinline isValid: (newValue: T) -> Boolean
+        noinline isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return gsonPrefImpl(key, defaultValue, object : TypeToken<T>() {}.type, isValid)
 }
@@ -65,7 +65,7 @@ internal fun <T : Any> Krate.gsonPrefImpl(
         key: String,
         defaultValue: T,
         type: Type,
-        isValid: (newValue: T) -> Boolean
+        isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return ValidatedPreferenceDelegate(GsonDelegateWithDefault(key, defaultValue, type), isValid)
 }

--- a/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/default/GsonDelegateWithDefault.kt
+++ b/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/default/GsonDelegateWithDefault.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty
 internal class GsonDelegateWithDefault<T : Any>(
         private val key: String,
         private val default: T,
-        private val type: Type
+        private val type: Type,
 ) : ReadWriteProperty<Krate, T> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): T {

--- a/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/optional/GsonDelegate.kt
+++ b/krate-gson/src/main/kotlin/hu/autsoft/krate/gson/optional/GsonDelegate.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KProperty
 
 internal class GsonDelegate<T : Any>(
         private val key: String,
-        private val type: Type
+        private val type: Type,
 ) : ReadWriteProperty<Krate, T?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): T? {

--- a/krate-gson/src/test/java/hu/autsoft/krate/gson/GsonTestKrate.kt
+++ b/krate-gson/src/test/java/hu/autsoft/krate/gson/GsonTestKrate.kt
@@ -2,6 +2,7 @@ package hu.autsoft.krate.gson
 
 import android.content.Context
 import hu.autsoft.krate.SimpleKrate
+import hu.autsoft.krate.validation.validate
 
 
 internal class GsonTestKrate(context: Context) : SimpleKrate(context) {
@@ -25,19 +26,16 @@ internal class GsonTestKrate(context: Context) : SimpleKrate(context) {
     var listOfValuesWithDefault: List<TestModel>
             by gsonPref("listOfValuesWithDefault", defaultValue = DEFAULT_LIST_VALUE)
 
-    var validatedValue: TestModel by gsonPref(
-            key = "validatedValue",
-            defaultValue = DEFAULT_SIMPLE_VALUE,
-            isValid = { newValue ->
-                newValue.x < newValue.y // arbitrary rule
-            }
-    )
+    var validatedValue: TestModel
+            by gsonPref(key = "validatedValue", defaultValue = DEFAULT_SIMPLE_VALUE)
+                    .validate { newValue ->
+                        newValue.x < newValue.y // arbitrary rule
+                    }
 
-    var validatedOptionalValue: List<TestModel>? by gsonPref(
-            key = "validatedOptionalValue",
-            isValid = { newValue ->
-                newValue.isNullOrEmpty().not()
-            }
-    )
+    var validatedOptionalValue: List<TestModel>?
+            by gsonPref<List<TestModel>>(key = "validatedOptionalValue")
+                    .validate { newValue ->
+                        newValue.isNullOrEmpty().not()
+                    }
 
 }

--- a/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
+++ b/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
@@ -16,6 +16,14 @@ import kotlin.reflect.typeOf
  * This value will be serialized using kotlinx.serialization.
  */
 @OptIn(ExperimentalStdlibApi::class)
+@Deprecated(
+        message = "Use .validate {} on a kotlinxPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.kotlinxPref<T>(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.kotlinxPref(
         key: String,
         noinline isValid: (newValue: T?) -> Boolean
@@ -38,6 +46,14 @@ internal fun <T : Any> Krate.kotlinxPrefImpl(
  * This value will be serialized using kotlinx.serialization.
  */
 @OptIn(ExperimentalStdlibApi::class)
+@Deprecated(
+        message = "Use .validate {} on a kotlinxPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.kotlinxPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.kotlinxPref(
         key: String,
         defaultValue: T,

--- a/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
+++ b/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
@@ -26,7 +26,7 @@ import kotlin.reflect.typeOf
 )
 public inline fun <reified T : Any> Krate.kotlinxPref(
         key: String,
-        noinline isValid: (newValue: T?) -> Boolean
+        noinline isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return kotlinxPrefImpl(key, typeOf<T>(), isValid)
 }
@@ -35,7 +35,7 @@ public inline fun <reified T : Any> Krate.kotlinxPref(
 internal fun <T : Any> Krate.kotlinxPrefImpl(
         key: String,
         type: KType,
-        isValid: (newValue: T?) -> Boolean
+        isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return ValidatedPreferenceDelegate(KotlinxDelegate(key, type), isValid)
 }
@@ -57,7 +57,7 @@ internal fun <T : Any> Krate.kotlinxPrefImpl(
 public inline fun <reified T : Any> Krate.kotlinxPref(
         key: String,
         defaultValue: T,
-        noinline isValid: (newValue: T) -> Boolean
+        noinline isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return kotlinxPrefImpl(key, defaultValue, typeOf<T>(), isValid)
 }
@@ -67,7 +67,7 @@ internal fun <T : Any> Krate.kotlinxPrefImpl(
         key: String,
         defaultValue: T,
         type: KType,
-        isValid: (newValue: T) -> Boolean
+        isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return ValidatedPreferenceDelegate(KotlinxDelegateWithDefault(key, defaultValue, type), isValid)
 }

--- a/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
+++ b/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/ValidatedFunctions.kt
@@ -6,7 +6,7 @@ import hu.autsoft.krate.Krate
 import hu.autsoft.krate.internal.InternalKrateApi
 import hu.autsoft.krate.kotlinx.default.KotlinxDelegateWithDefault
 import hu.autsoft.krate.kotlinx.optional.KotlinxDelegate
-import hu.autsoft.krate.validated.ValidatedPreferenceDelegate
+import hu.autsoft.krate.validation.ValidatedPreferenceDelegate
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KType
 import kotlin.reflect.typeOf

--- a/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/default/KotlinxDelegateWithDefault.kt
+++ b/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/default/KotlinxDelegateWithDefault.kt
@@ -13,7 +13,7 @@ import kotlin.reflect.KType
 internal class KotlinxDelegateWithDefault<T : Any>(
         private val key: String,
         private val default: T,
-        private val type: KType
+        private val type: KType,
 ) : ReadWriteProperty<Krate, T> {
 
     @Suppress("UNCHECKED_CAST")

--- a/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/optional/KotlinxDelegate.kt
+++ b/krate-kotlinx/src/main/kotlin/hu/autsoft/krate/kotlinx/optional/KotlinxDelegate.kt
@@ -12,7 +12,7 @@ import kotlin.reflect.KType
 
 internal class KotlinxDelegate<T : Any>(
         private val key: String,
-        private val type: KType
+        private val type: KType,
 ) : ReadWriteProperty<Krate, T?> {
 
     @Suppress("UNCHECKED_CAST")

--- a/krate-kotlinx/src/test/java/hu/autsoft/krate/kotlinx/KotlinxTestKrate.kt
+++ b/krate-kotlinx/src/test/java/hu/autsoft/krate/kotlinx/KotlinxTestKrate.kt
@@ -27,15 +27,15 @@ internal class KotlinxTestKrate(context: Context) : SimpleKrate(context) {
             by kotlinxPref("listOfValuesWithDefault", defaultValue = DEFAULT_LIST_VALUE)
 
     var validatedValue: TestModel
-            by kotlinxPref(key = "validatedValue",
-                    defaultValue = DEFAULT_SIMPLE_VALUE).validate { newValue ->
-                newValue.x < newValue.y // arbitrary rule
-            }
+            by kotlinxPref(key = "validatedValue", defaultValue = DEFAULT_SIMPLE_VALUE)
+                    .validate { newValue ->
+                        newValue.x < newValue.y // arbitrary rule
+                    }
 
     var validatedOptionalValue: List<TestModel>?
             by kotlinxPref<List<TestModel>>(key = "validatedOptionalValue")
                     .validate { newValue ->
-                        newValue.isNullOrEmpty().not()
+                        newValue.isNullOrEmpty().not() // arbitrary rule
                     }
 
 }

--- a/krate-kotlinx/src/test/java/hu/autsoft/krate/kotlinx/KotlinxTestKrate.kt
+++ b/krate-kotlinx/src/test/java/hu/autsoft/krate/kotlinx/KotlinxTestKrate.kt
@@ -2,6 +2,7 @@ package hu.autsoft.krate.kotlinx
 
 import android.content.Context
 import hu.autsoft.krate.SimpleKrate
+import hu.autsoft.krate.validation.validate
 
 
 internal class KotlinxTestKrate(context: Context) : SimpleKrate(context) {
@@ -25,19 +26,16 @@ internal class KotlinxTestKrate(context: Context) : SimpleKrate(context) {
     var listOfValuesWithDefault: List<TestModel>
             by kotlinxPref("listOfValuesWithDefault", defaultValue = DEFAULT_LIST_VALUE)
 
-    var validatedValue: TestModel by kotlinxPref(
-            key = "validatedValue",
-            defaultValue = DEFAULT_SIMPLE_VALUE,
-            isValid = { newValue ->
+    var validatedValue: TestModel
+            by kotlinxPref(key = "validatedValue",
+                    defaultValue = DEFAULT_SIMPLE_VALUE).validate { newValue ->
                 newValue.x < newValue.y // arbitrary rule
             }
-    )
 
-    var validatedOptionalValue: List<TestModel>? by kotlinxPref(
-            key = "validatedOptionalValue",
-            isValid = { newValue ->
-                newValue.isNullOrEmpty().not()
-            }
-    )
+    var validatedOptionalValue: List<TestModel>?
+            by kotlinxPref<List<TestModel>>(key = "validatedOptionalValue")
+                    .validate { newValue ->
+                        newValue.isNullOrEmpty().not()
+                    }
 
 }

--- a/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
+++ b/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
@@ -2,6 +2,7 @@ package hu.autsoft.krate.moshi
 
 import android.content.Context
 import hu.autsoft.krate.SimpleKrate
+import hu.autsoft.krate.validation.validate
 
 
 internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
@@ -25,19 +26,16 @@ internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
     var listOfValuesWithDefault: List<TestModel>
             by moshiPref("listOfValuesWithDefault", defaultValue = DEFAULT_LIST_VALUE)
 
-    var validatedValue: TestModel by moshiPref(
-            key = "validatedValue",
-            defaultValue = DEFAULT_SIMPLE_VALUE,
-            isValid = { newValue ->
-                newValue.x < newValue.y // arbitrary rule
-            }
-    )
+    var validatedValue: TestModel
+            by moshiPref(key = "validatedValue", defaultValue = DEFAULT_SIMPLE_VALUE)
+                    .validate { newValue ->
+                        newValue.x < newValue.y // arbitrary rule
+                    }
 
-    var validatedOptionalValue: List<TestModel>? by moshiPref(
-            key = "validatedOptionalValue",
-            isValid = { newValue ->
-                newValue.isNullOrEmpty().not()
-            }
-    )
+    var validatedOptionalValue: List<TestModel>?
+            by moshiPref<List<TestModel>>(key = "validatedOptionalValue")
+                    .validate { newValue ->
+                        newValue.isNullOrEmpty().not()
+                    }
 
 }

--- a/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
+++ b/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
@@ -35,7 +35,7 @@ internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
     var validatedOptionalValue: List<TestModel>?
             by moshiPref<List<TestModel>>(key = "validatedOptionalValue")
                     .validate { newValue ->
-                        newValue.isNullOrEmpty().not()
+                        newValue.isNullOrEmpty().not() // arbitrary rule
                     }
 
 }

--- a/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/test/ValidatedMoshiDelegateTest.kt
+++ b/krate-moshi-codegen/src/test/java/hu/autsoft/krate/moshi/test/ValidatedMoshiDelegateTest.kt
@@ -1,7 +1,9 @@
 package hu.autsoft.krate.moshi.test
 
+import com.squareup.moshi.Moshi
 import hu.autsoft.krate.moshi.MoshiTestKrate
 import hu.autsoft.krate.moshi.TestModel
+import hu.autsoft.krate.moshi.moshi
 import hu.autsoft.krate.moshi.util.targetContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -10,13 +12,16 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-internal class ValidatedGsonDelegateTest {
+internal class ValidatedMoshiDelegateTest {
 
     private lateinit var krate: MoshiTestKrate
 
     @Before
     fun setup() {
         krate = MoshiTestKrate(targetContext)
+
+        krate.moshi = Moshi.Builder().build()
+
     }
 
     @Test

--- a/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
+++ b/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
@@ -17,6 +17,14 @@ import kotlin.reflect.typeOf
  * This value will be serialized using Moshi.
  */
 @OptIn(ExperimentalStdlibApi::class)
+@Deprecated(
+        message = "Use .validate {} on a moshiPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.moshiPref<T>(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.moshiPref(
         key: String,
         noinline isValid: (newValue: T?) -> Boolean
@@ -28,7 +36,7 @@ public inline fun <reified T : Any> Krate.moshiPref(
 internal fun <T : Any> Krate.moshiPrefImpl(
         key: String,
         type: Type,
-        isValid: (newValue: T?) -> Boolean
+        isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return ValidatedPreferenceDelegate(MoshiDelegate(key, type), isValid)
 }
@@ -39,10 +47,18 @@ internal fun <T : Any> Krate.moshiPrefImpl(
  * This value will be serialized using Moshi.
  */
 @OptIn(ExperimentalStdlibApi::class)
+@Deprecated(
+        message = "Use .validate {} on a moshiPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.moshiPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public inline fun <reified T : Any> Krate.moshiPref(
         key: String,
         defaultValue: T,
-        noinline isValid: (newValue: T) -> Boolean
+        noinline isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return moshiPrefImpl(key, defaultValue, typeOf<T>().javaType, isValid)
 }

--- a/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
+++ b/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
@@ -27,7 +27,7 @@ import kotlin.reflect.typeOf
 )
 public inline fun <reified T : Any> Krate.moshiPref(
         key: String,
-        noinline isValid: (newValue: T?) -> Boolean
+        noinline isValid: (newValue: T?) -> Boolean,
 ): ReadWriteProperty<Krate, T?> {
     return moshiPrefImpl(key, typeOf<T>().javaType, isValid)
 }
@@ -68,7 +68,7 @@ internal fun <T : Any> Krate.moshiPrefImpl(
         key: String,
         defaultValue: T,
         type: Type,
-        isValid: (newValue: T) -> Boolean
+        isValid: (newValue: T) -> Boolean,
 ): ReadWriteProperty<Krate, T> {
     return ValidatedPreferenceDelegate(MoshiDelegateWithDefault(key, defaultValue, type), isValid)
 }

--- a/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
+++ b/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/ValidatedFunctions.kt
@@ -6,7 +6,7 @@ import hu.autsoft.krate.Krate
 import hu.autsoft.krate.internal.InternalKrateApi
 import hu.autsoft.krate.moshi.default.MoshiDelegateWithDefault
 import hu.autsoft.krate.moshi.optional.MoshiDelegate
-import hu.autsoft.krate.validated.ValidatedPreferenceDelegate
+import hu.autsoft.krate.validation.ValidatedPreferenceDelegate
 import java.lang.reflect.Type
 import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.javaType

--- a/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/default/MoshiDelegateWithDefault.kt
+++ b/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/default/MoshiDelegateWithDefault.kt
@@ -11,7 +11,7 @@ import kotlin.reflect.KProperty
 internal class MoshiDelegateWithDefault<T : Any>(
         private val key: String,
         private val default: T,
-        private val type: Type
+        private val type: Type,
 ) : ReadWriteProperty<Krate, T> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): T {

--- a/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/optional/MoshiDelegate.kt
+++ b/krate-moshi-core/src/main/kotlin/hu/autsoft/krate/moshi/optional/MoshiDelegate.kt
@@ -10,7 +10,7 @@ import kotlin.reflect.KProperty
 
 internal class MoshiDelegate<T : Any>(
         private val key: String,
-        private val type: Type
+        private val type: Type,
 ) : ReadWriteProperty<Krate, T?> {
 
     override fun getValue(thisRef: Krate, property: KProperty<*>): T? {

--- a/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
+++ b/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
@@ -2,6 +2,7 @@ package hu.autsoft.krate.moshi
 
 import android.content.Context
 import hu.autsoft.krate.SimpleKrate
+import hu.autsoft.krate.validation.validate
 
 
 internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
@@ -25,19 +26,16 @@ internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
     var listOfValuesWithDefault: List<TestModel>
             by moshiPref("listOfValuesWithDefault", defaultValue = DEFAULT_LIST_VALUE)
 
-    var validatedValue: TestModel by moshiPref(
-            key = "validatedValue",
-            defaultValue = DEFAULT_SIMPLE_VALUE,
-            isValid = { newValue ->
-                newValue.x < newValue.y // arbitrary rule
-            }
-    )
+    var validatedValue: TestModel
+            by moshiPref(key = "validatedValue", defaultValue = DEFAULT_SIMPLE_VALUE)
+                    .validate { newValue ->
+                        newValue.x < newValue.y // arbitrary rule
+                    }
 
-    var validatedOptionalValue: List<TestModel>? by moshiPref(
-            key = "validatedOptionalValue",
-            isValid = { newValue ->
-                newValue.isNullOrEmpty().not()
-            }
-    )
+    var validatedOptionalValue: List<TestModel>?
+            by moshiPref<List<TestModel>>(key = "validatedOptionalValue")
+                    .validate { newValue ->
+                        newValue.isNullOrEmpty().not()
+                    }
 
 }

--- a/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
+++ b/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/MoshiTestKrate.kt
@@ -35,7 +35,7 @@ internal class MoshiTestKrate(context: Context) : SimpleKrate(context) {
     var validatedOptionalValue: List<TestModel>?
             by moshiPref<List<TestModel>>(key = "validatedOptionalValue")
                     .validate { newValue ->
-                        newValue.isNullOrEmpty().not()
+                        newValue.isNullOrEmpty().not() // arbitrary rule
                     }
 
 }

--- a/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/test/ValidatedMoshiDelegateTest.kt
+++ b/krate-moshi-reflect/src/test/java/hu/autsoft/krate/moshi/test/ValidatedMoshiDelegateTest.kt
@@ -1,9 +1,7 @@
 package hu.autsoft.krate.moshi.test
 
-import com.squareup.moshi.Moshi
 import hu.autsoft.krate.moshi.MoshiTestKrate
 import hu.autsoft.krate.moshi.TestModel
-import hu.autsoft.krate.moshi.moshi
 import hu.autsoft.krate.moshi.util.targetContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
@@ -12,16 +10,13 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 
 @RunWith(RobolectricTestRunner::class)
-internal class ValidatedGsonDelegateTest {
+internal class ValidatedMoshiDelegateTest {
 
     private lateinit var krate: MoshiTestKrate
 
     @Before
     fun setup() {
         krate = MoshiTestKrate(targetContext)
-
-        krate.moshi = Moshi.Builder().build()
-
     }
 
     @Test

--- a/krate/build.gradle
+++ b/krate/build.gradle
@@ -27,7 +27,7 @@ tasks.withType(org.jetbrains.kotlin.gradle.tasks.KotlinCompile).all {
 }
 
 dependencies {
-    implementation"org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
     implementation 'androidx.preference:preference-ktx:1.1.1'
 
     testImplementation "junit:junit:$junit_version"

--- a/krate/src/main/kotlin/hu/autsoft/krate/SimpleKrate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/SimpleKrate.kt
@@ -14,7 +14,7 @@ import androidx.preference.PreferenceManager
  */
 public abstract class SimpleKrate(
         context: Context,
-        name: String? = null
+        name: String? = null,
 ) : Krate {
 
     public override val sharedPreferences: SharedPreferences = when (name) {

--- a/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
@@ -32,7 +32,7 @@ import kotlin.properties.ReadWriteProperty
 )
 public fun Krate.floatPref(
         key: String,
-        isValid: (newValue: Float?) -> Boolean
+        isValid: (newValue: Float?) -> Boolean,
 ): ReadWriteProperty<Krate, Float?> {
     return ValidatedPreferenceDelegate(FloatDelegate(key), isValid)
 }
@@ -55,7 +55,7 @@ public fun Krate.floatPref(
 public fun Krate.floatPref(
         key: String,
         defaultValue: Float,
-        isValid: (newValue: Float) -> Boolean
+        isValid: (newValue: Float) -> Boolean,
 ): ReadWriteProperty<Krate, Float> {
     return ValidatedPreferenceDelegate(FloatDelegateWithDefault(key, defaultValue), isValid)
 }
@@ -76,7 +76,7 @@ public fun Krate.floatPref(
 )
 public fun Krate.intPref(
         key: String,
-        isValid: (newValue: Int?) -> Boolean
+        isValid: (newValue: Int?) -> Boolean,
 ): ReadWriteProperty<Krate, Int?> {
     return ValidatedPreferenceDelegate(IntDelegate(key), isValid)
 }
@@ -99,7 +99,7 @@ public fun Krate.intPref(
 public fun Krate.intPref(
         key: String,
         defaultValue: Int,
-        isValid: (newValue: Int) -> Boolean
+        isValid: (newValue: Int) -> Boolean,
 ): ReadWriteProperty<Krate, Int> {
     return ValidatedPreferenceDelegate(IntDelegateWithDefault(key, defaultValue), isValid)
 }
@@ -120,7 +120,7 @@ public fun Krate.intPref(
 )
 public fun Krate.longPref(
         key: String,
-        isValid: (newValue: Long?) -> Boolean
+        isValid: (newValue: Long?) -> Boolean,
 ): ReadWriteProperty<Krate, Long?> {
     return ValidatedPreferenceDelegate(LongDelegate(key), isValid)
 }
@@ -143,7 +143,7 @@ public fun Krate.longPref(
 public fun Krate.longPref(
         key: String,
         defaultValue: Long,
-        isValid: (newValue: Long) -> Boolean
+        isValid: (newValue: Long) -> Boolean,
 ): ReadWriteProperty<Krate, Long> {
     return ValidatedPreferenceDelegate(LongDelegateWithDefault(key, defaultValue), isValid)
 }
@@ -164,7 +164,7 @@ public fun Krate.longPref(
 )
 public fun Krate.stringPref(
         key: String,
-        isValid: (newValue: String?) -> Boolean
+        isValid: (newValue: String?) -> Boolean,
 ): ReadWriteProperty<Krate, String?> {
     return ValidatedPreferenceDelegate(StringDelegate(key), isValid)
 }
@@ -187,7 +187,7 @@ public fun Krate.stringPref(
 public fun Krate.stringPref(
         key: String,
         defaultValue: String,
-        isValid: (newValue: String) -> Boolean
+        isValid: (newValue: String) -> Boolean,
 ): ReadWriteProperty<Krate, String> {
     return ValidatedPreferenceDelegate(StringDelegateWithDefault(key, defaultValue), isValid)
 }
@@ -208,7 +208,7 @@ public fun Krate.stringPref(
 )
 public fun Krate.stringSetPref(
         key: String,
-        isValid: (newValue: Set<String>?) -> Boolean
+        isValid: (newValue: Set<String>?) -> Boolean,
 ): ReadWriteProperty<Krate, Set<String>?> {
     return ValidatedPreferenceDelegate(StringSetDelegate(key), isValid)
 }
@@ -231,7 +231,7 @@ public fun Krate.stringSetPref(
 public fun Krate.stringSetPref(
         key: String,
         defaultValue: Set<String>,
-        isValid: (newValue: Set<String>) -> Boolean
+        isValid: (newValue: Set<String>) -> Boolean,
 ): ReadWriteProperty<Krate, Set<String>> {
     return ValidatedPreferenceDelegate(StringSetDelegateWithDefault(key, defaultValue), isValid)
 }

--- a/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
@@ -22,6 +22,14 @@ import kotlin.properties.ReadWriteProperty
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a floatPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.floatPref(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public fun Krate.floatPref(
         key: String,
         isValid: (newValue: Float?) -> Boolean
@@ -35,6 +43,15 @@ public fun Krate.floatPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a floatPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.floatPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
+
 public fun Krate.floatPref(
         key: String,
         defaultValue: Float,
@@ -49,6 +66,14 @@ public fun Krate.floatPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on an intPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.intPref(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public fun Krate.intPref(
         key: String,
         isValid: (newValue: Int?) -> Boolean
@@ -62,6 +87,15 @@ public fun Krate.intPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on an intPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.intPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
+
 public fun Krate.intPref(
         key: String,
         defaultValue: Int,
@@ -76,6 +110,14 @@ public fun Krate.intPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a longPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.longPref(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public fun Krate.longPref(
         key: String,
         isValid: (newValue: Long?) -> Boolean
@@ -89,6 +131,15 @@ public fun Krate.longPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a longPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.longPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
+
 public fun Krate.longPref(
         key: String,
         defaultValue: Long,
@@ -103,6 +154,14 @@ public fun Krate.longPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a stringPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.stringPref(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public fun Krate.stringPref(
         key: String,
         isValid: (newValue: String?) -> Boolean
@@ -116,6 +175,15 @@ public fun Krate.stringPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a stringPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.stringPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
+
 public fun Krate.stringPref(
         key: String,
         defaultValue: String,
@@ -130,6 +198,14 @@ public fun Krate.stringPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a stringSetPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.stringSetPref(key).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
 public fun Krate.stringSetPref(
         key: String,
         isValid: (newValue: Set<String>?) -> Boolean
@@ -143,6 +219,15 @@ public fun Krate.stringSetPref(
  * If a value being set to this preference returns `false` when checked by [isValid],
  * an [IllegalArgumentException] will be thrown.
  */
+@Deprecated(
+        message = "Use .validate {} on a stringSetPref instead",
+        level = DeprecationLevel.WARNING,
+        replaceWith = ReplaceWith(
+                "this.stringSetPref(key, defaultValue).validate(isValid)",
+                imports = arrayOf("hu.autsoft.krate.validation.validate"),
+        ),
+)
+
 public fun Krate.stringSetPref(
         key: String,
         defaultValue: Set<String>,

--- a/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
@@ -51,7 +51,6 @@ public fun Krate.floatPref(
                 imports = arrayOf("hu.autsoft.krate.validation.validate"),
         ),
 )
-
 public fun Krate.floatPref(
         key: String,
         defaultValue: Float,
@@ -95,7 +94,6 @@ public fun Krate.intPref(
                 imports = arrayOf("hu.autsoft.krate.validation.validate"),
         ),
 )
-
 public fun Krate.intPref(
         key: String,
         defaultValue: Int,
@@ -139,7 +137,6 @@ public fun Krate.longPref(
                 imports = arrayOf("hu.autsoft.krate.validation.validate"),
         ),
 )
-
 public fun Krate.longPref(
         key: String,
         defaultValue: Long,
@@ -183,7 +180,6 @@ public fun Krate.stringPref(
                 imports = arrayOf("hu.autsoft.krate.validation.validate"),
         ),
 )
-
 public fun Krate.stringPref(
         key: String,
         defaultValue: String,
@@ -227,7 +223,6 @@ public fun Krate.stringSetPref(
                 imports = arrayOf("hu.autsoft.krate.validation.validate"),
         ),
 )
-
 public fun Krate.stringSetPref(
         key: String,
         defaultValue: Set<String>,

--- a/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/ValidatedFunctions.kt
@@ -13,7 +13,7 @@ import hu.autsoft.krate.optional.IntDelegate
 import hu.autsoft.krate.optional.LongDelegate
 import hu.autsoft.krate.optional.StringDelegate
 import hu.autsoft.krate.optional.StringSetDelegate
-import hu.autsoft.krate.validated.ValidatedPreferenceDelegate
+import hu.autsoft.krate.validation.ValidatedPreferenceDelegate
 import kotlin.properties.ReadWriteProperty
 
 /**

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/BooleanDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/BooleanDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class BooleanDelegateWithDefault(
         private val key: String,
-        private val default: Boolean
+        private val default: Boolean,
 ) : ReadWriteProperty<Krate, Boolean> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Boolean {

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/FloatDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/FloatDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class FloatDelegateWithDefault(
         private val key: String,
-        private val default: Float
+        private val default: Float,
 ) : ReadWriteProperty<Krate, Float> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Float {

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/IntDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/IntDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class IntDelegateWithDefault(
         private val key: String,
-        private val default: Int
+        private val default: Int,
 ) : ReadWriteProperty<Krate, Int> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Int {

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/LongDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/LongDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class LongDelegateWithDefault(
         private val key: String,
-        private val default: Long
+        private val default: Long,
 ) : ReadWriteProperty<Krate, Long> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Long {

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/StringDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/StringDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class StringDelegateWithDefault(
         private val key: String,
-        private val default: String
+        private val default: String,
 ) : ReadWriteProperty<Krate, String> {
 
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")

--- a/krate/src/main/kotlin/hu/autsoft/krate/default/StringSetDelegateWithDefault.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/default/StringSetDelegateWithDefault.kt
@@ -7,7 +7,7 @@ import kotlin.reflect.KProperty
 
 internal class StringSetDelegateWithDefault(
         private val key: String,
-        private val default: Set<String>
+        private val default: Set<String>,
 ) : ReadWriteProperty<Krate, Set<String>> {
 
     @Suppress("NULLABILITY_MISMATCH_BASED_ON_JAVA_ANNOTATIONS")

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/BooleanDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/BooleanDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class BooleanDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, Boolean?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Boolean? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/FloatDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/FloatDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class FloatDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, Float?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Float? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/IntDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/IntDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class IntDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, Int?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Int? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/LongDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/LongDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class LongDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, Long?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Long? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/StringDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/StringDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class StringDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, String?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): String? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/optional/StringSetDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/optional/StringSetDelegate.kt
@@ -6,7 +6,7 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 internal class StringSetDelegate(
-        private val key: String
+        private val key: String,
 ) : ReadWriteProperty<Krate, Set<String>?> {
 
     override operator fun getValue(thisRef: Krate, property: KProperty<*>): Set<String>? {

--- a/krate/src/main/kotlin/hu/autsoft/krate/validation/ValidatedPreferenceDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/validation/ValidatedPreferenceDelegate.kt
@@ -6,11 +6,11 @@ import kotlin.properties.ReadWriteProperty
 import kotlin.reflect.KProperty
 
 /**
- * [ValidatedPreferenceDelegate] is a generic [ReadWriteProperty] that can be used to
- * validate values that are being set.
+ * A generic [ReadWriteProperty] that can be used to validate values that are being set
+ * into another delegate.
  *
- * @param [delegate] the [ReadWriteProperty] implementation that is used for delegation
- * @param [isValid] the lambda used to validate property values on [setValue]
+ * If a value being set to this preference returns `false` when checked by [isValid],
+ * an [IllegalArgumentException] will be thrown.
  */
 @InternalKrateApi
 public class ValidatedPreferenceDelegate<T>(

--- a/krate/src/main/kotlin/hu/autsoft/krate/validation/ValidatedPreferenceDelegate.kt
+++ b/krate/src/main/kotlin/hu/autsoft/krate/validation/ValidatedPreferenceDelegate.kt
@@ -1,4 +1,4 @@
-package hu.autsoft.krate.validated
+package hu.autsoft.krate.validation
 
 import hu.autsoft.krate.Krate
 import hu.autsoft.krate.internal.InternalKrateApi
@@ -15,7 +15,7 @@ import kotlin.reflect.KProperty
 @InternalKrateApi
 public class ValidatedPreferenceDelegate<T>(
         private val delegate: ReadWriteProperty<Krate, T>,
-        private val isValid: (newValue: T) -> Boolean
+        private val isValid: (newValue: T) -> Boolean,
 ) : ReadWriteProperty<Krate, T> by delegate {
 
     override operator fun setValue(thisRef: Krate, property: KProperty<*>, value: T) {
@@ -24,4 +24,26 @@ public class ValidatedPreferenceDelegate<T>(
         delegate.setValue(thisRef, property, value)
     }
 
+}
+
+/**
+ * Adds validation to a Krate delegate.
+ *
+ * If a value being set to this preference returns `false` when checked by [isValid],
+ * an [IllegalArgumentException] will be thrown.
+ *
+ * Example property using this function for validation:
+ *
+ * ```kotlin
+ * var validatedString by stringPref("validatedString", "default")
+ *      .validate { newValue ->
+ *          newValue.length > 3 // arbitrary condition
+ *      }
+ * ```
+ */
+public fun <T : Any?> ReadWriteProperty<Krate, T>.validate(
+        isValid: (newValue: T) -> Boolean,
+): ReadWriteProperty<Krate, T> {
+    @OptIn(InternalKrateApi::class)
+    return ValidatedPreferenceDelegate(this, isValid)
 }

--- a/krate/src/test/java/hu/autsoft/krate/TestKrate.kt
+++ b/krate/src/test/java/hu/autsoft/krate/TestKrate.kt
@@ -15,13 +15,9 @@ internal class TestKrate(context: Context) : SimpleKrate(context) {
     var optionalLong by longPref("optionalLong")
     var optionalString by stringPref("optionalString")
     var optionalStringSet by stringSetPref("optionalStringSet")
-    var optionalValidatedString by stringPref("validatedString")
-            .validate {
-                it?.length ?: 5 == 5
-            }
-    var defaultValidatedFloat by floatPref("defaultFloat", 0.0f)
-            .validate {
-                it in 0.0f..1.0f
-            }
+    var optionalValidatedString by stringPref("optionalValidatedString")
+            .validate { it?.length ?: 5 == 5 }
+    var defaultValidatedFloat by floatPref("defaultValidatedFloat", 0.0f)
+            .validate { it in 0.0f..1.0f }
 
 }

--- a/krate/src/test/java/hu/autsoft/krate/TestKrate.kt
+++ b/krate/src/test/java/hu/autsoft/krate/TestKrate.kt
@@ -1,6 +1,7 @@
 package hu.autsoft.krate
 
 import android.content.Context
+import hu.autsoft.krate.validation.validate
 
 internal class TestKrate(context: Context) : SimpleKrate(context) {
 
@@ -14,11 +15,13 @@ internal class TestKrate(context: Context) : SimpleKrate(context) {
     var optionalLong by longPref("optionalLong")
     var optionalString by stringPref("optionalString")
     var optionalStringSet by stringSetPref("optionalStringSet")
-    var optionalValidatedString by stringPref("validatedString") {
-        it?.length ?: 5 == 5
-    }
-    var defaultValidatedFloat by floatPref("defaultFloat", 0.0f) {
-        it in 0.0f..1.0f
-    }
+    var optionalValidatedString by stringPref("validatedString")
+            .validate {
+                it?.length ?: 5 == 5
+            }
+    var defaultValidatedFloat by floatPref("defaultFloat", 0.0f)
+            .validate {
+                it in 0.0f..1.0f
+            }
 
 }

--- a/krate/src/test/java/hu/autsoft/krate/test/DefaultTests.kt
+++ b/krate/src/test/java/hu/autsoft/krate/test/DefaultTests.kt
@@ -1,5 +1,7 @@
-package hu.autsoft.krate
+package hu.autsoft.krate.test
 
+import hu.autsoft.krate.TestKrate
+import hu.autsoft.krate.targetContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test

--- a/krate/src/test/java/hu/autsoft/krate/test/OptionalTests.kt
+++ b/krate/src/test/java/hu/autsoft/krate/test/OptionalTests.kt
@@ -1,5 +1,7 @@
-package hu.autsoft.krate
+package hu.autsoft.krate.test
 
+import hu.autsoft.krate.TestKrate
+import hu.autsoft.krate.targetContext
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Test


### PR DESCRIPTION
Replaces the old separate, per-delegate validated function with a single extension that can be applied on top of any existing delegate.

Example of this new API:

```kotlin
var percentage: Int by intPref(
        key = "percentage",
        defaultValue = 0,
).validate { it in 0..100 }
```

The old validating delegate functions are now deprecated with a `WARNING` level set, will be `ERROR` in the release after, and then eventually removed. Removing these will also let us remove `@InternalKrateApi` entirely at that point.